### PR TITLE
Fix typo of trained_model_path

### DIFF
--- a/GraphBP/main_gen.py
+++ b/GraphBP/main_gen.py
@@ -19,7 +19,7 @@ focus_th = 0.5
 contact_th = 0.5
 num_gen = 100 # number generate for each reference rec-lig pair
 
-trained_model_path = 'trained_mode'
+trained_model_path = 'trained_model'
 epochs = [33]
 
 


### PR DESCRIPTION
This PR fixes the typo of directory name of model path.